### PR TITLE
Include vector in header files that use it

### DIFF
--- a/include/dwarfpp/attr.hpp
+++ b/include/dwarfpp/attr.hpp
@@ -10,6 +10,7 @@
 #define __DWARFPP_ATTR_HPP
 
 #include <memory>
+#include <vector>
 
 #include "spec.hpp"
 #include "private/libdwarf.hpp" /* includes libdwarf.h, Error, No_entry, some fwddecls */

--- a/include/dwarfpp/expr.hpp
+++ b/include/dwarfpp/expr.hpp
@@ -8,6 +8,7 @@
 #ifndef __DWARFPP_EXPR_HPP
 #define __DWARFPP_EXPR_HPP
 
+#include <vector>
 #include <boost/icl/interval_map.hpp>
 #include <strings.h> // for bzero
 #include "spec.hpp"


### PR DESCRIPTION
Building with boost 1.61.0-2 fails because vector is not included, this fixes it.