### PR TITLE
Compilation and distribution patches

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,15 @@ dwarfpp_include_HEADERS = include/dwarfpp/dwarf-onlystd.h include/dwarfpp/frame.
   include/dwarfpp/opt.hpp include/dwarfpp/dwarf-current-adt.h include/dwarfpp/regs.hpp \
   include/dwarfpp/dwarf-current-factory.h include/dwarfpp/dwarf-ext-GNU.h \
   include/dwarfpp/expr.hpp include/dwarfpp/spec.hpp \
+  include/dwarfpp/util.hpp \
+  include/dwarfpp/abstract.hpp \
+  include/dwarfpp/root.hpp \
+  include/dwarfpp/iter.hpp \
+  include/dwarfpp/dies.hpp \
+  include/dwarfpp/root-inl.hpp \
+  include/dwarfpp/abstract-inl.hpp \
+  include/dwarfpp/iter-inl.hpp \
+  include/dwarfpp/dies-inl.hpp \
   include/dwarfpp/libdwarf-handles.hpp include/dwarfpp/libdwarf.hpp
 
 lib_LTLIBRARIES = src/libdwarfpp.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,10 +55,10 @@ include/dwarfpp/dwarf-ext-GNU.h: $(libdwarf_includes)/dwarf.h
 	cat "$<" | egrep '(_|/\* |, )GNU' | egrep -vi conflict | egrep -vi '^[[:blank:]]*/\*' | cat > "$@"
 
 include/dwarfpp/dwarf-current-adt.h: spec/gen-adt-cpp.py spec/dwarf_current.py
-	python spec/gen-adt-cpp.py > "$@"
+	python2 spec/gen-adt-cpp.py > "$@"
 
 include/dwarfpp/dwarf-current-factory.h: spec/gen-factory-cpp.py spec/dwarf_current.py
-	python spec/gen-factory-cpp.py > "$@"
+	python2 spec/gen-factory-cpp.py > "$@"
 
 # to avoid propagating libdwarf CFLAGS into all clients, symlink the libdwarf.h we use
 include/libdwarf.h: $(libdwarf_includes)/libdwarf.h

--- a/spec/gen-adt-cpp.py
+++ b/spec/gen-adt-cpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 

--- a/src/dies.cpp
+++ b/src/dies.cpp
@@ -2556,8 +2556,9 @@ namespace dwarf
 					 * not in any cycle. We want to cache this fact. */
 					for (auto i_t = types.first; i_t != types.second; ++i_t)
 					{
-						if (i_t->second) i_t->second->opt_cached_scc
-						= opt<shared_ptr<type_scc_t> >(shared_ptr<type_scc_t>());
+						if (i_t->second)
+							i_t->second->opt_cached_scc =
+								opt<shared_ptr<type_scc_t> >();
 					}
 				}
 				else

--- a/src/spec/adt-gen.py
+++ b/src/spec/adt-gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # What needs to be generated?
 # - abstract class template definitions


### PR DESCRIPTION
Before b23628b, `dies.cpp` prevented me from compiling with gcc 8.1.1