### PR TITLE
Use dwarfdump from submodule in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,17 @@
 /Makefile
 
+# Python
 __pycache__/
 *.py[cod]
 
+# libtool
 .deps/
 .libs/
 
-
 # http://www.gnu.org/software/automake
-
 Makefile.in
 
 # http://www.gnu.org/software/autoconf
-
 .dirstamp
 /autom4te.cache
 /aclocal.m4
@@ -27,6 +26,7 @@ Makefile.in
 /config.sub
 /config.status
 /config.log
+/config.mk
 /ltmain.sh
 /libtool
 /include/dwarfpp/config.h
@@ -44,6 +44,9 @@ include/dwarfpp/dwarf-lib.h
 include/dwarfpp/dwarf-onlystd-v2.h
 include/dwarfpp/dwarf-onlystd.h
 
+# built library symlinks
+/lib/
+
 # built example programs
 examples/core-query
 examples/dwarfppdump
@@ -52,12 +55,32 @@ examples/sranges
 examples/subseq
 examples/eh-frame-hdr
 
+# built test programs
+# Use `git status -s | grep '?? tests' | cut -c 4- >> .gitignore` to add new tests
+tests/all-sccs/all-sccs
+tests/core-bfs/core-bfs
+tests/core-variadic/core-variadic
+tests/coretest/coretest
+tests/fde-decode/fde-decode
+tests/fde-print/fde-print
+tests/grandchildren/grandchildren
+tests/live-dies/live-dies
+tests/make-dies/make-dies
+tests/resolve/resolve
+tests/siblings-core/siblings-core
+tests/timed-dump-core/timed-dump-core
+tests/type-equality/type-equality
+tests/type-iterators/type-iterators
+tests/type-scc/type-scc
+tests/visible-named/visible-named
+
 # Compiled Object files
 *.slo
 *.lo
 *.o
 *.obj
 
+# pkg-config
 *.pc
 
 # Dependencies
@@ -86,14 +109,12 @@ examples/eh-frame-hdr
 *.out
 *.app
 
-
 # Backup files
 *~
 \#*\#
 .\#*
 
 # WTF Dropbox
-
 .fuse_hidden*
 .nfs*
 .dropbox*

--- a/tests/timed-dump-core/timed-dump-core.cpp
+++ b/tests/timed-dump-core/timed-dump-core.cpp
@@ -13,7 +13,7 @@ int main(int argc, char **argv)
 	std::ifstream in(argv[0]);
 	core::root_die root(fileno(in));
 
-	int status0 = system("./exit-deciseconds.sh sh -c 'dwarfdump ../../examples/dwarfppdump >/dev/null 2>/dev/null'");
+	int status0 = system("./exit-deciseconds.sh sh -c '../../contrib/libdwarf/prefix/bin/dwarfdump ../../examples/dwarfppdump >/dev/null 2>/dev/null'");
 	int status1 = system("./exit-deciseconds.sh sh -c 'readelf -wi ../../examples/dwarfppdump >/dev/null 2>/dev/null'");
 	int status2 = system("./exit-deciseconds.sh sh -c '../../examples/dwarfppdump ../../examples/dwarfppdump >/dev/null 2>/dev/null'");
 	


### PR DESCRIPTION
It seems reasonable to expect that those developing `libdwarfpp` will be
doing so with the submodules checked out and built, so we can rely on
the built `dwarfdump` from `libdwarf`, rather than whatever version
comes from the surrounding host distro.

This also does some `.gitignore` gardening as well.