### PR TITLE
Use CircleCI for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2.0
+jobs:
+  build:
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            apt update && apt install -y git build-essential make \
+            autoconf automake libtool pkg-config autoconf-archive \
+            g\+\+ python3 python2.7 python-minimal \
+            libelf-dev libboost-iostreams-dev libboost-regex-dev \
+            libboost-serialization-dev libboost-filesystem-dev
+      - checkout
+      - run:
+          name: Update submodules
+          command: git submodule update --init
+      - run:
+          name: Build submodules
+          command: make -C contrib -j 2
+      - run:
+          name: Build project
+          command: |
+            . contrib/env.sh
+            ./autogen.sh
+            ./configure
+            make -j 2
+      - run:
+          name: Run tests
+          command: make -C tests -j 2


### PR DESCRIPTION
This defines the workflow steps CircleCI should run to build and test this repo.

For a preview of the end result, you can take a look at my fork's [commit list](https://github.com/jryans/libdwarfpp/commits/circleci) where the top commit has a green check for passing CI:

![image](https://user-images.githubusercontent.com/279572/65049183-3ec82200-d95d-11e9-8317-5441a4410611.png)

Clicking on the green check leads to the [test results](https://circleci.com/gh/jryans/libdwarfpp/12):

![image](https://user-images.githubusercontent.com/279572/65049261-615a3b00-d95d-11e9-9897-f195e3ac3c94.png)

CI jobs will run for pushes and pull requests by default. Pull requests will be annotated with similar pass / fail icons depending on CI status.

This does require a few steps to set up on your own repo, so I have attempted to list them out to ease the process:

1. Merge this pull request to add CircleCI configuration to the repo
2. Go to https://circleci.com/signup/ to create an account (if needed)
3. Sign up with GitHub and authorise access (use triangle on button to choose public or all repos)
    * You can revoke access via https://github.com/settings/applications if you no longer want to use it in the future
4. Click "Add Projects" on the left hand navigation bar
5. Find the repo on the page and click "Set Up Project"
6. Scroll down past all the getting started text and click "Start building" to use the merged config
7. We need to change a setting to also build pull requests from forks to help contributors, so from the CircleCI "Workflows" page, click the gear icon for the repo
    * This should take you to https://circleci.com/gh/stephenrkell/libdwarfpp/edit
8. Click "Advanced Settings", and enable "Build forked pull requests"

If you would rather not worry about CI yourself, let me know and we can discuss ways to move forward. I think it will be quite helpful for contributors especially, but hopefully for you as well. 😄