### PR TITLE
Ensure PT_GNU_EH_FRAME program header has non-zero size

### DIFF
--- a/src/frame.cpp
+++ b/src/frame.cpp
@@ -571,7 +571,7 @@ namespace dwarf
 				GElf_Phdr *ret_phdr;
 				ret_phdr = gelf_getphdr(e, i, &phdr);
 				assert(ret_phdr); if (!ret_phdr) abort();
-				if (phdr.p_type == PT_GNU_EH_FRAME)
+				if (phdr.p_type == PT_GNU_EH_FRAME && phdr.p_filesz > 0)
 				{
 					break;
 				}


### PR DESCRIPTION
With Ubuntu 18.04, I appear to have libc debug info that has a
PT_GNU_EH_FRAME program header, but with a file size 0, which I assume
is invalid. Instead of crashing, this ignores the program header.